### PR TITLE
closedir() expects parameter 1 to be resource

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -182,7 +182,7 @@ echo '<?xml version="1.0" encoding="utf-8" ?>';
             }
         }
 
-        closedir($files_dir);
+        closedir($directory);
 
         ?>
 


### PR DESCRIPTION
I was repeatedly getting this error. 

I think the correct solution is in line 185:

Changing 

'''php
        closedir($files_dir);
'''

to 
'''php
        closedir($directory);
'''